### PR TITLE
Introduce "project" view

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -2,7 +2,7 @@ import { useNote } from '../useNote';
 import Editor from './Editor';
 
 export default function App() {
-  const [note, saveNote] = useNote();
+  const [note, saveNote, setPreview] = useNote();
 
-  return <Editor note={note} saveNote={saveNote} />;
+  return <Editor note={note} saveNote={saveNote} setPreview={setPreview} />;
 }

--- a/src/components/Editor.test.tsx
+++ b/src/components/Editor.test.tsx
@@ -9,11 +9,10 @@ test('UI renders table headers', () => {
     screen.getByRole('columnheader', { name: 'Project' })
   ).toBeInTheDocument();
   expect(
-    screen.getByRole('columnheader', { name: 'Start' })
-  ).toBeInTheDocument();
-  expect(screen.getByRole('columnheader', { name: 'End' })).toBeInTheDocument();
-  expect(
     screen.getByRole('columnheader', { name: 'Duration' })
+  ).toBeInTheDocument();
+  expect(
+    screen.getByRole('columnheader', { name: 'Action' })
   ).toBeInTheDocument();
 });
 

--- a/src/components/Editor.test.tsx
+++ b/src/components/Editor.test.tsx
@@ -43,5 +43,7 @@ test('UI renders stop button after clicking', () => {
 function LocalStateEditor() {
   let [note, saveNote] = useState('');
 
-  return <Editor note={note} saveNote={saveNote} />;
+  return (
+    <Editor note={note} saveNote={saveNote} setPreview={() => undefined} />
+  );
 }

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -27,9 +27,10 @@ export enum HtmlElementId {
 interface Props {
   note: string;
   saveNote: (newNote: string) => void;
+  setPreview: (newPreview: string) => void;
 }
 
-export default function Editor({ note, saveNote }: Props) {
+export default function Editor({ note, saveNote, setPreview }: Props) {
   const [nextProject, setNextProject] = useState('');
 
   let [completedRecords, activeRecord] = parseRecords(note);
@@ -38,6 +39,7 @@ export default function Editor({ note, saveNote }: Props) {
     (sum, project) => sum.plus(project.totalTime),
     Duration.ZERO
   );
+  setPreview(`Total: ${formatSeconds(sumAllProjects.toMillis() / 1000)}`);
 
   return (
     <div
@@ -140,15 +142,6 @@ export default function Editor({ note, saveNote }: Props) {
           </Tbody>
         </Table>
       </TableContainer>
-      {projects.length > 0 && (
-        <Box
-          padding={'var(--chakra-space-5) var(--chakra-space-8)'}
-          textAlign={'right'}
-        >
-          Total:&nbsp;
-          <FixedDuration duration={sumAllProjects} />
-        </Box>
-      )}
     </div>
   );
 }

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -38,118 +38,116 @@ export default function Editor({ note, saveNote }: Props) {
   );
 
   return (
-    <>
-      <div
-        className={HtmlElementId.snComponent}
-        id={HtmlElementId.snComponent}
-        tabIndex={0}
+    <div
+      className={HtmlElementId.snComponent}
+      id={HtmlElementId.snComponent}
+      tabIndex={0}
+    >
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          let newNote = insertRecord(
+            note,
+            nextProject,
+            OffsetDateTime.now(ZoneId.UTC)
+          );
+          setNextProject('');
+          saveNote(newNote);
+        }}
       >
-        <form
-          onSubmit={(e) => {
-            e.preventDefault();
-            let newNote = insertRecord(
-              note,
-              nextProject,
-              OffsetDateTime.now(ZoneId.UTC)
-            );
-            setNextProject('');
-            saveNote(newNote);
-          }}
-        >
-          <SimpleGrid columns={2}>
-            <Input
-              height="100%"
-              placeholder={'What are you working on?'}
-              value={nextProject}
-              onChange={(event) => setNextProject(event.target.value)}
-            />
-            <Button
-              width="100%"
-              padding="2rem"
-              type="submit"
-              disabled={!nextProject}
-            >
-              Start timer
-            </Button>
-          </SimpleGrid>
-        </form>
-        <TableContainer>
-          <Table size="lg">
-            <Thead>
-              <Tr>
-                <Th>Project</Th>
-                <Th>Duration</Th>
-                <Th>Action</Th>
+        <SimpleGrid columns={2}>
+          <Input
+            height="100%"
+            placeholder={'What are you working on?'}
+            value={nextProject}
+            onChange={(event) => setNextProject(event.target.value)}
+          />
+          <Button
+            width="100%"
+            padding="2rem"
+            type="submit"
+            disabled={!nextProject}
+          >
+            Start timer
+          </Button>
+        </SimpleGrid>
+      </form>
+      <TableContainer>
+        <Table size="lg">
+          <Thead>
+            <Tr>
+              <Th>Project</Th>
+              <Th>Duration</Th>
+              <Th>Action</Th>
+            </Tr>
+          </Thead>
+          <Tbody>
+            {projects.length > 0 && (
+              <Tr
+                key={'total'}
+                borderBottom={'2px solid rgba(128, 128, 128, 0.2)'}
+              >
+                <Td>Total</Td>
+                <Td>
+                  <FixedDuration duration={sumAllProjects} />
+                </Td>
+                <Td></Td>
               </Tr>
-            </Thead>
-            <Tbody>
-              {projects.length > 0 && (
-                <Tr
-                  key={'total'}
-                  borderBottom={'2px solid rgba(128, 128, 128, 0.2)'}
-                >
-                  <Td>Total</Td>
-                  <Td>
-                    <FixedDuration duration={sumAllProjects} />
-                  </Td>
-                  <Td></Td>
-                </Tr>
-              )}
-              {activeRecord && (
-                <Tr
-                  key="active"
-                  backgroundColor="green.50"
-                  borderBottom={'3px solid rgba(128, 128, 128, 0.2)'}
-                >
-                  <Td>{activeRecord.project}</Td>
-                  <Td>
-                    <DynamicDuration start={activeRecord.start} />
-                  </Td>
-                  <Td>
-                    <Button
-                      width="100%"
-                      onClick={() => {
-                        let newNote = stopCurrentRecord(
-                          note,
-                          OffsetDateTime.now(ZoneId.UTC)
-                        );
-                        saveNote(newNote);
-                      }}
-                    >
-                      Stop timer
-                    </Button>
-                  </Td>
-                </Tr>
-              )}
-              {projects.map((project) => (
-                <Tr key={project.name}>
-                  <Td>{project.name}</Td>
-                  <Td>
-                    <FixedDuration duration={project.totalTime} />
-                  </Td>
-                  <Td>
-                    <Button
-                      width="100%"
-                      disabled={!!activeRecord}
-                      onClick={() => {
-                        let newNote = insertRecord(
-                          note,
-                          project.name,
-                          OffsetDateTime.now(ZoneId.UTC)
-                        );
-                        saveNote(newNote);
-                      }}
-                    >
-                      Start timer
-                    </Button>
-                  </Td>
-                </Tr>
-              ))}
-            </Tbody>
-          </Table>
-        </TableContainer>
-      </div>
-    </>
+            )}
+            {activeRecord && (
+              <Tr
+                key="active"
+                backgroundColor="green.50"
+                borderBottom={'3px solid rgba(128, 128, 128, 0.2)'}
+              >
+                <Td>{activeRecord.project}</Td>
+                <Td>
+                  <DynamicDuration start={activeRecord.start} />
+                </Td>
+                <Td>
+                  <Button
+                    width="100%"
+                    onClick={() => {
+                      let newNote = stopCurrentRecord(
+                        note,
+                        OffsetDateTime.now(ZoneId.UTC)
+                      );
+                      saveNote(newNote);
+                    }}
+                  >
+                    Stop timer
+                  </Button>
+                </Td>
+              </Tr>
+            )}
+            {projects.map((project) => (
+              <Tr key={project.name}>
+                <Td>{project.name}</Td>
+                <Td>
+                  <FixedDuration duration={project.totalTime} />
+                </Td>
+                <Td>
+                  <Button
+                    width="100%"
+                    disabled={!!activeRecord}
+                    onClick={() => {
+                      let newNote = insertRecord(
+                        note,
+                        project.name,
+                        OffsetDateTime.now(ZoneId.UTC)
+                      );
+                      saveNote(newNote);
+                    }}
+                  >
+                    Start timer
+                  </Button>
+                </Td>
+              </Tr>
+            ))}
+          </Tbody>
+        </Table>
+      </TableContainer>
+    </div>
   );
 }
 

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 import {
   Box,
   Button,
-  Divider,
   Input,
   SimpleGrid,
   Table,

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -1,6 +1,8 @@
 import React, { useState } from 'react';
 import {
+  Box,
   Button,
+  Divider,
   Input,
   SimpleGrid,
   Table,
@@ -43,35 +45,42 @@ export default function Editor({ note, saveNote }: Props) {
       id={HtmlElementId.snComponent}
       tabIndex={0}
     >
-      <form
-        onSubmit={(e) => {
-          e.preventDefault();
-          let newNote = insertRecord(
-            note,
-            nextProject,
-            OffsetDateTime.now(ZoneId.UTC)
-          );
-          setNextProject('');
-          saveNote(newNote);
-        }}
+      <Box
+        borderBottom={'1px solid var(--chakra-colors-chakra-border-color)'}
+        paddingTop={'1px'}
       >
-        <SimpleGrid columns={2}>
-          <Input
-            height="100%"
-            placeholder={'What are you working on?'}
-            value={nextProject}
-            onChange={(event) => setNextProject(event.target.value)}
-          />
-          <Button
-            width="100%"
-            padding="2rem"
-            type="submit"
-            disabled={!nextProject}
-          >
-            Start timer
-          </Button>
-        </SimpleGrid>
-      </form>
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            let newNote = insertRecord(
+              note,
+              nextProject,
+              OffsetDateTime.now(ZoneId.UTC)
+            );
+            setNextProject('');
+            saveNote(newNote);
+          }}
+        >
+          <SimpleGrid columns={2}>
+            <Input
+              height="100%"
+              placeholder={'What are you working on?'}
+              value={nextProject}
+              border={'0px'}
+              borderRadius={0}
+              onChange={(event) => setNextProject(event.target.value)}
+            />
+            <Button
+              padding="2rem"
+              type="submit"
+              borderRadius={0}
+              disabled={!nextProject}
+            >
+              Start timer
+            </Button>
+          </SimpleGrid>
+        </form>
+      </Box>
       <TableContainer>
         <Table size="lg">
           <Thead>
@@ -82,24 +91,8 @@ export default function Editor({ note, saveNote }: Props) {
             </Tr>
           </Thead>
           <Tbody>
-            {projects.length > 0 && (
-              <Tr
-                key={'total'}
-                borderBottom={'2px solid rgba(128, 128, 128, 0.2)'}
-              >
-                <Td>Total</Td>
-                <Td>
-                  <FixedDuration duration={sumAllProjects} />
-                </Td>
-                <Td></Td>
-              </Tr>
-            )}
             {activeRecord && (
-              <Tr
-                key="active"
-                backgroundColor="green.50"
-                borderBottom={'3px solid rgba(128, 128, 128, 0.2)'}
-              >
+              <Tr key="active" backgroundColor="green.50">
                 <Td>{activeRecord.project}</Td>
                 <Td>
                   <DynamicDuration start={activeRecord.start} />
@@ -147,6 +140,15 @@ export default function Editor({ note, saveNote }: Props) {
           </Tbody>
         </Table>
       </TableContainer>
+      {projects.length > 0 && (
+        <Box
+          padding={'var(--chakra-space-5) var(--chakra-space-8)'}
+          textAlign={'right'}
+        >
+          Total:&nbsp;
+          <FixedDuration duration={sumAllProjects} />
+        </Box>
+      )}
     </div>
   );
 }

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -32,6 +32,10 @@ export default function Editor({ note, saveNote }: Props) {
 
   let [completedRecords, activeRecord] = parseRecords(note);
   let projects = parseProjects(completedRecords);
+  let sumAllProjects = projects.reduce(
+    (sum, project) => sum.plus(project.totalTime),
+    Duration.ZERO
+  );
 
   return (
     <>
@@ -70,7 +74,7 @@ export default function Editor({ note, saveNote }: Props) {
           </SimpleGrid>
         </form>
         <TableContainer>
-          <Table variant="simple" size="lg">
+          <Table size="lg">
             <Thead>
               <Tr>
                 <Th>Project</Th>
@@ -79,8 +83,24 @@ export default function Editor({ note, saveNote }: Props) {
               </Tr>
             </Thead>
             <Tbody>
+              {projects.length > 0 && (
+                <Tr
+                  key={'total'}
+                  borderBottom={'2px solid rgba(128, 128, 128, 0.2)'}
+                >
+                  <Td>Total</Td>
+                  <Td>
+                    <FixedDuration duration={sumAllProjects} />
+                  </Td>
+                  <Td></Td>
+                </Tr>
+              )}
               {activeRecord && (
-                <Tr key="active" backgroundColor="green.50">
+                <Tr
+                  key="active"
+                  backgroundColor="green.50"
+                  borderBottom={'3px solid rgba(128, 128, 128, 0.2)'}
+                >
                   <Td>{activeRecord.project}</Td>
                   <Td>
                     <DynamicDuration start={activeRecord.start} />
@@ -146,17 +166,16 @@ interface DynamicDurationProps {
 }
 
 function DynamicDuration({ start }: DynamicDurationProps) {
+  const duration = useDynamicDuration(start);
+
+  return <FixedDuration duration={duration} />;
+}
+
+function useDynamicDuration(start: OffsetDateTime) {
   let [end, setEnd] = useState(Instant.now());
   useInterval(() => {
     setEnd(Instant.now());
   }, 1000);
 
-  return (
-    <FixedDuration
-      duration={Duration.between(
-        start,
-        OffsetDateTime.ofInstant(end, ZoneId.UTC)
-      )}
-    />
-  );
+  return Duration.between(start, OffsetDateTime.ofInstant(end, ZoneId.UTC));
 }

--- a/src/note.test.ts
+++ b/src/note.test.ts
@@ -4,7 +4,7 @@ import { Instant, OffsetDateTime, ZoneId } from '@js-joda/core';
 test('can parse a record', () => {
   let record = '1,libp2p,2022-06-24T16:35:15.000Z,2022-06-24T18:35:45.000Z';
 
-  let records = parseRecords(record);
+  let [records, _activeRecord] = parseRecords(record);
 
   expect(records).toStrictEqual([
     {

--- a/src/project.test.ts
+++ b/src/project.test.ts
@@ -1,9 +1,9 @@
-import { Record } from './note';
+import { CompletedRecord } from './note';
 import { Duration, OffsetDateTime, ZoneOffset } from '@js-joda/core';
 import { parseProjects } from './project';
 
 test('should sum time records of projects', () => {
-  let timeRecords: Record[] = [
+  let timeRecords: CompletedRecord[] = [
     {
       id: 1,
       project: 'foo',
@@ -39,7 +39,7 @@ test('should sum time records of projects', () => {
 });
 
 test('should ignore records without end time', () => {
-  let timeRecords: Record[] = [
+  let timeRecords: CompletedRecord[] = [
     {
       id: 1,
       project: 'foo',
@@ -51,11 +51,6 @@ test('should ignore records without end time', () => {
       project: 'bar',
       start: aTimestamp(2),
       end: aTimestamp(4),
-    },
-    {
-      id: 3,
-      project: 'foo',
-      start: aTimestamp(4),
     },
   ];
 
@@ -74,7 +69,7 @@ test('should ignore records without end time', () => {
 });
 
 test('should sort records based on duration', () => {
-  let timeRecords: Record[] = [
+  let timeRecords: CompletedRecord[] = [
     {
       id: 1,
       project: 'foo',

--- a/src/project.test.ts
+++ b/src/project.test.ts
@@ -1,0 +1,114 @@
+import { Record } from './note';
+import { Duration, OffsetDateTime, ZoneOffset } from '@js-joda/core';
+import { parseProjects } from './project';
+
+test('should sum time records of projects', () => {
+  let timeRecords: Record[] = [
+    {
+      id: 1,
+      project: 'foo',
+      start: aTimestamp(0),
+      end: aTimestamp(2),
+    },
+    {
+      id: 2,
+      project: 'bar',
+      start: aTimestamp(2),
+      end: aTimestamp(4),
+    },
+    {
+      id: 3,
+      project: 'foo',
+      start: aTimestamp(4),
+      end: aTimestamp(7),
+    },
+  ];
+
+  const projects = parseProjects(timeRecords);
+
+  expect(projects).toStrictEqual([
+    {
+      name: 'foo',
+      totalTime: Duration.ofHours(5),
+    },
+    {
+      name: 'bar',
+      totalTime: Duration.ofHours(2),
+    },
+  ]);
+});
+
+test('should ignore records without end time', () => {
+  let timeRecords: Record[] = [
+    {
+      id: 1,
+      project: 'foo',
+      start: aTimestamp(0),
+      end: aTimestamp(2),
+    },
+    {
+      id: 2,
+      project: 'bar',
+      start: aTimestamp(2),
+      end: aTimestamp(4),
+    },
+    {
+      id: 3,
+      project: 'foo',
+      start: aTimestamp(4),
+    },
+  ];
+
+  const projects = parseProjects(timeRecords);
+
+  expect(projects).toStrictEqual([
+    {
+      name: 'foo',
+      totalTime: Duration.ofHours(2),
+    },
+    {
+      name: 'bar',
+      totalTime: Duration.ofHours(2),
+    },
+  ]);
+});
+
+test('should sort records based on duration', () => {
+  let timeRecords: Record[] = [
+    {
+      id: 1,
+      project: 'foo',
+      start: aTimestamp(0),
+      end: aTimestamp(2),
+    },
+    {
+      id: 2,
+      project: 'bar',
+      start: aTimestamp(2),
+      end: aTimestamp(7),
+    },
+    {
+      id: 3,
+      project: 'foo',
+      start: aTimestamp(7),
+      end: aTimestamp(8),
+    },
+  ];
+
+  const projects = parseProjects(timeRecords);
+
+  expect(projects).toStrictEqual([
+    {
+      name: 'bar',
+      totalTime: Duration.ofHours(5),
+    },
+    {
+      name: 'foo',
+      totalTime: Duration.ofHours(3),
+    },
+  ]);
+});
+
+function aTimestamp(hour: number) {
+  return OffsetDateTime.of(2022, 10, 8, hour, 0, 0, 0, ZoneOffset.UTC);
+}

--- a/src/project.ts
+++ b/src/project.ts
@@ -1,4 +1,4 @@
-import { Record } from './note';
+import { CompletedRecord } from './note';
 import { Duration } from '@js-joda/core';
 
 /// Consolidated data of all records for a single project.
@@ -9,15 +9,11 @@ export interface Project {
   totalTime: Duration;
 }
 
-export function parseProjects(records: Record[]): Project[] {
+export function parseProjects(records: CompletedRecord[]): Project[] {
   const projects: Project[] = [];
 
   records
     .reduce((projects, record) => {
-      if (!record.end) {
-        return projects;
-      }
-
       const newDuration = Duration.between(record.start, record.end);
       const existingDuration = projects.get(record.project) ?? Duration.ZERO;
 

--- a/src/project.ts
+++ b/src/project.ts
@@ -1,0 +1,38 @@
+import { Record } from './note';
+import { Duration } from '@js-joda/core';
+
+/// Consolidated data of all records for a single project.
+export interface Project {
+  name: string;
+  // firstEntry: OffsetDateTime;
+  // lastEntry: OffsetDateTime;
+  totalTime: Duration;
+}
+
+export function parseProjects(records: Record[]): Project[] {
+  const projects: Project[] = [];
+
+  records
+    .reduce((projects, record) => {
+      if (!record.end) {
+        return projects;
+      }
+
+      const newDuration = Duration.between(record.start, record.end);
+      const existingDuration = projects.get(record.project) ?? Duration.ZERO;
+
+      projects.set(record.project, existingDuration.plus(newDuration));
+
+      return projects;
+    }, new Map())
+    .forEach((duration, project) => {
+      projects.push({
+        name: project,
+        totalTime: duration,
+      });
+    });
+
+  projects.sort((a, b) => b.totalTime.compareTo(a.totalTime));
+
+  return projects;
+}

--- a/src/useNote.ts
+++ b/src/useNote.ts
@@ -1,15 +1,21 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import EditorKitBase from '@standardnotes/editor-kit';
 
-export function useNote(): [string, (newText: string) => void] {
+export function useNote(): [
+  string,
+  (newText: string) => void,
+  (newPreview: string) => void
+] {
   let [note, setNote] = useState('');
   let [editorKit, setEditorKit] = useState<EditorKitBase | null>(null);
+  let preview = useRef<string>();
 
   useEffect(() => {
     let editorKit = new EditorKitBase(
       {
         setEditorRawText: (text: string) => setNote(text),
         insertRawText: (text: string) => setNote(text),
+        generateCustomPreview: () => ({ plain: preview.current ?? '' }),
       },
       {
         mode: 'plaintext',
@@ -24,6 +30,9 @@ export function useNote(): [string, (newText: string) => void] {
     (newText: string) => {
       editorKit?.onEditorValueChanged(newText);
       setNote(newText);
+    },
+    (newPreview) => {
+      preview.current = newPreview;
     },
   ];
 }


### PR DESCRIPTION
This PR introduces a project-based view:

![image](https://user-images.githubusercontent.com/5486389/194691678-71a0559f-1672-416d-ac42-23b19f2de770.png)

Instead of rendering the internal data representation (time records), we group records by project and sum up the duration. The total is displayed in the preview of the note. Additionally, each existing item now has a button to "continue" working on it.