### PR TITLE
Dynamically change column sizes

### DIFF
--- a/src/components/Editor.test.tsx
+++ b/src/components/Editor.test.tsx
@@ -9,7 +9,7 @@ test('UI renders table headers', () => {
     screen.getByRole('columnheader', { name: 'Project' })
   ).toBeInTheDocument();
   expect(
-    screen.getByRole('columnheader', { name: 'Time' })
+    screen.getByRole('columnheader', { name: 'Duration' })
   ).toBeInTheDocument();
   expect(
     screen.getByRole('columnheader', { name: 'Action' })
@@ -19,7 +19,7 @@ test('UI renders table headers', () => {
 test('UI renders start but not stop button', () => {
   render(<LocalStateEditor />);
 
-  let startButton = screen.getByRole('button', { name: 'Start timer' });
+  let startButton = screen.getByRole('button', { name: 'Start' });
 
   expect(startButton).toBeInTheDocument();
 });
@@ -27,7 +27,7 @@ test('UI renders start but not stop button', () => {
 test('UI renders stop button after clicking', () => {
   render(<LocalStateEditor />);
 
-  let startButton = screen.getByRole('button', { name: 'Start timer' });
+  let startButton = screen.getByRole('button', { name: 'Start' });
   let projectInput = screen.getByRole('textbox'); // TODO: Add name here
 
   fireEvent.change(projectInput, {

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -9,13 +9,6 @@ import {
   HStack,
   Input,
   SimpleGrid,
-  Table,
-  TableContainer,
-  Tbody,
-  Td,
-  Th,
-  Thead,
-  Tr,
 } from '@chakra-ui/react';
 import {
   ActiveRecord,

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -155,6 +155,7 @@ interface HeadingProps {
 function Heading({ text, ...other }: HeadingProps & GridItemProps) {
   return (
     <GridItem
+      role={'columnheader'}
       textTransform={'uppercase'}
       fontSize={'sm'}
       textColor={'gray.500'}

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -1,7 +1,11 @@
 import React, { useState } from 'react';
 import {
   Box,
+  BoxProps,
   Button,
+  Grid,
+  GridItem,
+  GridItemProps,
   HStack,
   Input,
   SimpleGrid,
@@ -83,58 +87,106 @@ export default function Editor({ note, saveNote, setPreview }: Props) {
               padding="2rem"
               type="submit"
               borderRadius={0}
-              disabled={!nextProject}
+              disabled={!nextProject || !!activeRecord}
             >
-              Start timer
+              Start
             </Button>
           </SimpleGrid>
         </form>
       </Box>
-      <TableContainer>
-        <Table size="lg">
-          <Thead>
-            <Tr>
-              <Th>Project</Th>
-              <Th>Time</Th>
-              <Th>Action</Th>
-            </Tr>
-          </Thead>
-          <Tbody>
-            {activeRecord && (
-              <ActiveRecordRow
-                activeRecord={activeRecord}
-                note={note}
-                saveNote={saveNote}
-              />
-            )}
-            {projects.map((project) => (
-              <Tr key={project.name}>
-                <Td>{project.name}</Td>
-                <Td>
-                  <FormattedDuration duration={project.totalTime} />
-                </Td>
-                <Td>
-                  <Button
-                    width="100%"
-                    disabled={!!activeRecord}
-                    onClick={() => {
-                      let newNote = insertRecord(
-                        note,
-                        project.name,
-                        OffsetDateTime.now(ZoneId.UTC)
-                      );
-                      saveNote(newNote);
-                    }}
-                  >
-                    Start timer
-                  </Button>
-                </Td>
-              </Tr>
-            ))}
-          </Tbody>
-        </Table>
-      </TableContainer>
+      <Grid
+        templateRows={'auto 1fr'}
+        templateColumns={'2fr minmax(50px, auto) 1fr'}
+        columnGap={5}
+        rowGap={5}
+        alignItems={'center'}
+      >
+        <GridItem colSpan={3} />
+
+        <Heading text={'Project'} paddingLeft={5} />
+        <Heading text={'Duration'} />
+        <Heading text={'Action'} paddingRight={5} />
+
+        <GridItem
+          colSpan={3}
+          borderBottom={'1px solid var(--chakra-colors-chakra-border-color)'}
+        />
+
+        {activeRecord && (
+          <ActiveRecordRow
+            activeRecord={activeRecord}
+            note={note}
+            saveNote={saveNote}
+          />
+        )}
+        {projects.map((project) => (
+          <>
+            <ProjectName
+              key={`project-${project.name}`}
+              name={project.name}
+              paddingLeft={5}
+            />
+            <FormattedDuration
+              key={`duration-${project.name}`}
+              duration={project.totalTime}
+            />
+            <GridItem paddingRight={5}>
+              <Button
+                key={`actions-${project.name}`}
+                width="100%"
+                disabled={!!activeRecord}
+                fontSize={'xl'}
+                onClick={() => {
+                  let newNote = insertRecord(
+                    note,
+                    project.name,
+                    OffsetDateTime.now(ZoneId.UTC)
+                  );
+                  saveNote(newNote);
+                }}
+              >
+                Start
+              </Button>
+            </GridItem>
+          </>
+        ))}
+      </Grid>
     </div>
+  );
+}
+
+interface HeadingProps {
+  text: string;
+}
+
+function Heading({ text, ...other }: HeadingProps & GridItemProps) {
+  return (
+    <GridItem
+      textTransform={'uppercase'}
+      fontSize={'sm'}
+      textColor={'gray.500'}
+      fontWeight={'bold'}
+      {...other}
+    >
+      {text}
+    </GridItem>
+  );
+}
+
+interface ProjectNameProps {
+  name: string;
+}
+
+function ProjectName({ name, ...other }: ProjectNameProps & BoxProps) {
+  return (
+    <Box
+      textOverflow={'ellipsis'}
+      overflow={'hidden'}
+      whiteSpace={'nowrap'}
+      {...other}
+    >
+      {name}
+    </Box>
   );
 }
 
@@ -142,8 +194,11 @@ interface FixedDurationProps {
   duration: Duration;
 }
 
-function FormattedDuration({ duration }: FixedDurationProps) {
-  return <span>{formatSeconds(duration.toMillis() / 1000)}</span>;
+function FormattedDuration({
+  duration,
+  ...other
+}: FixedDurationProps & BoxProps) {
+  return <Box {...other}>{formatSeconds(duration.toMillis() / 1000)}</Box>;
 }
 
 interface ActiveRecordProps {
@@ -160,46 +215,50 @@ function ActiveRecordRow({ activeRecord, note, saveNote }: ActiveRecordProps) {
   const startPlus1m = activeRecord.start.plus(Duration.ofMinutes(1));
 
   return (
-    <Tr key="active" backgroundColor="green.50">
-      <Td>{activeRecord.project}</Td>
-      <Td>
-        <FormattedDuration duration={duration} />
-      </Td>
-      <Td>
-        <HStack gap={'1'}>
-          <Button
-            disabled={isBeforeEndOfLastCompleted(note, startMinus1m)}
-            onClick={() => {
-              let newNote = changeStartOfCurrentRecord(note, startMinus1m);
-              saveNote(newNote);
-            }}
-          >
-            +1m
-          </Button>
-          <Button
-            flexGrow={1}
-            onClick={() => {
-              let newNote = stopCurrentRecord(
-                note,
-                OffsetDateTime.now(ZoneId.UTC)
-              );
-              saveNote(newNote);
-            }}
-          >
-            Stop
-          </Button>
-          <Button
-            disabled={isLessThanOneMinute}
-            onClick={() => {
-              let newNote = changeStartOfCurrentRecord(note, startPlus1m);
-              saveNote(newNote);
-            }}
-          >
-            -1m
-          </Button>
-        </HStack>
-      </Td>
-    </Tr>
+    <>
+      <ProjectName
+        key={'activeProject'}
+        name={activeRecord.project}
+        paddingLeft={5}
+      />
+      <FormattedDuration key={'activeDuration'} duration={duration} />
+      <HStack key={'activeActions'} gap={'1'} paddingRight={5}>
+        <Button
+          key={'plus1mButton'}
+          disabled={isBeforeEndOfLastCompleted(note, startMinus1m)}
+          onClick={() => {
+            let newNote = changeStartOfCurrentRecord(note, startMinus1m);
+            saveNote(newNote);
+          }}
+        >
+          +1m
+        </Button>
+        <Button
+          key={'stopButton'}
+          flexGrow={1}
+          fontSize={'xl'}
+          onClick={() => {
+            let newNote = stopCurrentRecord(
+              note,
+              OffsetDateTime.now(ZoneId.UTC)
+            );
+            saveNote(newNote);
+          }}
+        >
+          Stop
+        </Button>
+        <Button
+          key={'minus1mButton'}
+          disabled={isLessThanOneMinute}
+          onClick={() => {
+            let newNote = changeStartOfCurrentRecord(note, startPlus1m);
+            saveNote(newNote);
+          }}
+        >
+          -1m
+        </Button>
+      </HStack>
+    </>
   );
 }
 


### PR DESCRIPTION
Instead of using a table, we rebuild the layout using a grid which allows us to more precisely describe, how much width each column should consume. This allows us to avoid any overflows while at the same time have the "Project" column take up as much space as possible.